### PR TITLE
Bump version of ghost to 4.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghost",
-  "version": "4.10.0",
+  "version": "4.21.0",
   "description": "Deploy Ghost v4 on Railway",
   "main": "index.js",
   "author": "farazpatankar",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "casper": "github:TryGhost/Casper#main",
-    "ghost": "4.10.0",
+    "ghost": "4.21.0",
     "ghost-storage-cloudinary": "^2.1.5",
     "lyra": "github:TryGhost/lyra#main",
     "mysql2": "^2.2.5"


### PR DESCRIPTION
Bumping the base version of ghost for new starter projects to allow users to take advantage of new features from Ghost.